### PR TITLE
Add ability to output in plaintext

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,46 @@
 
 This action will take the information from the Push/Pull Request and output some variables and write files that will let you know what was changed, removed, or added.
 
-## Use Cases
+## Inputs
 
-I have a process where I have AWS Cloudformation templates stored in one directory that might be named PRODUCT-ROLE, and mappings for these templates that span the PRODUCT.  For example **mappings/wordpress.mappings.yml, templates/wordpress-database.yml, templates/wordpress-webserver.yml**, and some of the templates might use different Lambda functions defined in for example **functions/wordpress-webserver/**.
+### githubToken
 
-In the example below we have a workflow that on *push* to the develop branch we can perform some actions based on the files.  In my use case I look for changes on the develop branch of this repository for every push that happens.  When a push happens and a change is made to any of the paths below the workflow will trigger.  With this action you are able to know exactly which files changed so that you can make decisions later in your CI/CD.
+**Required**  - string - your github token
 
-In this case, if a **templates/*.yml** file is changed, then we want to update the Cloudformation stack.  We can also write specifics for related templates.  For example, if **templates/wordpress-database.yml** changes then we want to deploy **templates/wordpress-webserver.yml** as well after.
+### output
 
-Another case is if the **mappings/wordpress.mappings.yml** changes, we want to deploy all **template/wordpress-*.yml** files.
+_Optional_  - string - type of output for output variables, default is json.  Use ',' for comma separated values, or ' ' for space delimited values.  You can also create your own delimiter for example ' |FILE:' will output 'file1.yml |FILE:file2.yml |FILE:file3.yml'.
+
+### fileOutput
+
+_Optional_  - string - type of output for file output, default is json.  Use ',' for comma separated values, or ' ' for space delimited values.  You can also create your own delimiter for example ' |FILE:' will output 'file1.yml |FILE:file2.yml |FILE:file3.yml'.  If you select json then the file format will be .json, if you select ',' then the file format will be .csv, anything else will output the files as .txt
+
+## Outputs
+
+### files
+
+**Required** - string - The names all new, updated, and deleted files.  The output is dependant on the output input, default is a json string.
+
+### files_added
+
+**Required** - string - The names of the newly created files.  The output is dependant on the output input, default is a json string.
+
+### files_modified
+
+**Required** - string - The names of the updated files.  The output is dependant on the output input, default is a json string.
+
+### files_deleted
+
+**Required** - string - The names of the deleted files.  The output is dependant on the output input, default is a json string.
+
+## Example usage
+
+```yaml
+id: file_changes
+uses: trilom/file-changes-action@v1
+with:
+  githubToken: ${{ secrets.GITHUB_TOKEN }}
+```
 
 ## How to Use
 
@@ -21,17 +52,57 @@ If a push is made then it will compare commits from the SHA `github.context.payl
 
 After gathering this information it will output the files in 2 ways.  
   
-- As an output variable, you can use this variable by using `steps.file_changes.outputs.files_modified`, `steps.file_changes.outputs.files_added`, `steps.file_changes.outputs.files_deleted`.
+- As an output variable, you can use this variable by using `steps.file_changes_outputs_files`, `steps.file_changes.outputs.files_modified`, `steps.file_changes.outputs.files_added`, `steps.file_changes.outputs.files_deleted`.
 
-- As a file on the container stored at `$HOME/files.json`, `$HOME/files_modified.json`, `$HOME/files_added.json`, `$HOME/files_deleted.json`.  Example:
+- As a file on the container stored at `$HOME/files.json`, `$HOME/files_modified.json`, `$HOME/files_added.json`, `$HOME/files_deleted.json`.  
 
-```files_added.json
-["cloudformation/mappings/wordpress.mappings.yml","cloudformation/templates/wordpress-database.yml"]
+- _NOTE:_ If you set a custom delimiter in output or fileOutput inputs then you will receive different files.  For example a delimiter of ',' will output at `$HOME/files.csv` instead of `$HOME/files.json`.  Likewise, anything other than 'json' or ',' delmiters will output `$HOME/files.txt` files instead of `$HOME/files.json` by default.
+
+## Use Cases
+
+I have a process where I have AWS Cloudformation templates stored in one directory that might be named PRODUCT-ROLE, and mappings for these templates that span the PRODUCT.  For example **mappings/wordpress.mappings.yml, templates/wordpress-database.yml, templates/wordpress-webserver.yml**, and some of the templates might use different Lambda functions defined in for example **functions/wordpress-webserver/**.
+
+In the example below we have a workflow that on *push* to the develop branch we can perform some actions based on the files.  In my use case I look for changes on the develop branch of this repository for every push that happens.  When a push happens and a change is made to any of the paths below the workflow will trigger.  With this action you are able to know exactly which files changed so that you can make decisions later in your CI/CD.
+
+In this case, if a **templates/*.yml** file is changed, then we want to update the Cloudformation stack.  We can also write specifics for related templates.  For example, if **templates/wordpress-database.yml** changes then we want to deploy **templates/wordpress-webserver.yml** as well after.
+
+Another case is if the **mappings/wordpress.mappings.yml** changes, we want to deploy all **template/wordpress-*.yml** files.
+
+## More examples  
+
+```yaml
+name: push-develop
+
+on:
+  push:
+    branches:
+      - develop
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: file_changes
+        uses: trilom/file-changes-action@v1
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+      - name: test
+        run: |
+          ls $HOME
+          cat $HOME/files.json
+          cat $HOME/files_modified.json
+          cat $HOME/files_added.json
+          cat $HOME/files_deleted.json
+          echo '${{ steps.file_changes.outputs.files}}'
+          echo '${{ steps.file_changes.outputs.files_modified}}'
+          echo '${{ steps.file_changes.outputs.files_added}}'
+          echo '${{ steps.file_changes.outputs.files_deleted}}'
 ```
 
-## Examples  
+You can set the output and fileOutput to ',' for csv output.
 
-```yaml .github/workflows/push_develop.yml
+```yaml
 name: push-develop
 
 on:
@@ -52,14 +123,39 @@ jobs:
         uses: trilom/file-changes-action@v1
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+          output: ','
+          fileOutput: ','
       - name: test
         run: |
-          ls $HOME
-          cat $HOME/files.json
-          cat $HOME/files_modified.json
-          cat $HOME/files_added.json
-          cat $HOME/files_deleted.json
-          echo '${{ steps.file_changes.outputs.files_modified}}'
-          echo '${{ steps.file_changes.outputs.files_added}}'
-          echo '${{ steps.file_changes.outputs.files_deleted}}'
+          cat $HOME/files.csv
+```
+
+You can set the output and fileOutput to ' ' for txt output.
+
+```yaml
+name: push-develop
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'cloudformation/templates/*.yml'
+      - 'cloudformation/mappings/*.yml'
+      - 'functions/*'
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - id: file_changes
+        uses: trilom/file-changes-action@v1
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          output: ' '
+          fileOutput: ' '
+      - name: test
+        run: |
+          cat $HOME/files.txt
 ```

--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,17 @@ inputs:
   githubToken:
     description: 'The GITHUB_TOKEN secret if necessary'
     required: false
-  plaintext:
-    description: 'If true, outputs in plain text instead of JSON string array'
-    required: false
+  output:
+    description: 'Choose between json (default), or custom delimiter by passing a string, for example '','' for csv variable output'
+    required: true
+    default: json
+  fileOutput:
+    description: 'Choose between json (default), or custom delimiter by passing a string, for example '','' for csv file output.  If you set as json the file output will be suffixed with .json, if you select '','' then the output will be .csv, else .txt will be the output.'
+    required: true
+    default: json
 outputs:
+  files:
+    description: 'The names all new, updated, and deleted files'
   files_added:
     description: 'The names of the newly created files'
   files_modified:

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   githubToken:
     description: 'The GITHUB_TOKEN secret if necessary'
     required: false
+  plaintext:
+    description: 'If true, outputs in plain text instead of JSON string array'
+    required: false
 outputs:
   files_added:
     description: 'The names of the newly created files'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1703,6 +1703,30 @@ class ChangedFiles {
         this.deleted = [];
         this.files = [];
     }
+  getOutput(files) {
+    if (core.getInput('plaintext')) {
+      return files.join(' ')
+    } else {
+      return JSON.stringify(files)
+    }
+  }
+
+	createdOutput() {
+    return this.getOutput(this.created)
+  }
+
+  fileOutput() {
+    return this.getOutput(this.files)
+  }
+
+  updatedOutput() {
+    return this.getOutput(this.updated)
+  }
+
+  deletedOutput() {
+    return this.getOutput(this.deleted)
+  }
+
 }
 class File {
     constructor() {
@@ -1792,14 +1816,15 @@ function run() {
                 return;
             }
             //write files to preserve original functionality
-            fs.writeFileSync(`${process.env.HOME}/files.json`, JSON.stringify(changedFiles.files), 'utf-8');
-            fs.writeFileSync(`${process.env.HOME}/files_modified.json`, JSON.stringify(changedFiles.updated), 'utf-8');
-            fs.writeFileSync(`${process.env.HOME}/files_added.json`, JSON.stringify(changedFiles.created), 'utf-8');
-            fs.writeFileSync(`${process.env.HOME}/files_deleted.json`, JSON.stringify(changedFiles.deleted), 'utf-8');
+            fs.writeFileSync(`${process.env.HOME}/files.json`, changedFiles.fileOutput(), 'utf-8');
+            fs.writeFileSync(`${process.env.HOME}/files_modified.json`, changedFiles.updatedOutput(), 'utf-8');
+            fs.writeFileSync(`${process.env.HOME}/files_added.json`, changedFiles.createdOutput(), 'utf-8');
+            fs.writeFileSync(`${process.env.HOME}/files_deleted.json`, changedFiles.deletedOutput(), 'utf-8');
             //also export some outputs
-            core.setOutput('files_added', JSON.stringify(changedFiles.created));
-            core.setOutput('files_modified', JSON.stringify(changedFiles.updated));
-            core.setOutput('files_deleted', JSON.stringify(changedFiles.deleted));
+						core.setOutput('files', changedFiles.fileOutput())
+						core.setOutput('files_added', changedFiles.createdOutput())
+						core.setOutput('files_modified', changedFiles.updatedOutput())
+						core.setOutput('files_deleted', changedFiles.deletedOutput())
             process.exit(0);
         }
         catch (error) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -27,6 +27,26 @@ class ChangedFiles {
         this.deleted = [];
         this.files = [];
     }
+    getOutput(files) {
+        if (core.getInput('plaintext')) {
+            return files.join(' ');
+        }
+        else {
+            return JSON.stringify(files);
+        }
+    }
+    createdOutput() {
+        return this.getOutput(this.created);
+    }
+    fileOutput() {
+        return this.getOutput(this.files);
+    }
+    updatedOutput() {
+        return this.getOutput(this.updated);
+    }
+    deletedOutput() {
+        return this.getOutput(this.deleted);
+    }
 }
 class File {
     constructor() {
@@ -116,14 +136,15 @@ function run() {
                 return;
             }
             //write files to preserve original functionality
-            fs.writeFileSync(`${process.env.HOME}/files.json`, JSON.stringify(changedFiles.files), 'utf-8');
-            fs.writeFileSync(`${process.env.HOME}/files_modified.json`, JSON.stringify(changedFiles.updated), 'utf-8');
-            fs.writeFileSync(`${process.env.HOME}/files_added.json`, JSON.stringify(changedFiles.created), 'utf-8');
-            fs.writeFileSync(`${process.env.HOME}/files_deleted.json`, JSON.stringify(changedFiles.deleted), 'utf-8');
+            fs.writeFileSync(`${process.env.HOME}/files.json`, changedFiles.fileOutput(), 'utf-8');
+            fs.writeFileSync(`${process.env.HOME}/files_modified.json`, changedFiles.updatedOutput(), 'utf-8');
+            fs.writeFileSync(`${process.env.HOME}/files_added.json`, changedFiles.createdOutput(), 'utf-8');
+            fs.writeFileSync(`${process.env.HOME}/files_deleted.json`, changedFiles.deletedOutput(), 'utf-8');
             //also export some outputs
-            core.setOutput('files_added', JSON.stringify(changedFiles.created));
-            core.setOutput('files_modified', JSON.stringify(changedFiles.updated));
-            core.setOutput('files_deleted', JSON.stringify(changedFiles.deleted));
+            core.setOutput('files', changedFiles.fileOutput());
+            core.setOutput('files_added', changedFiles.createdOutput());
+            core.setOutput('files_modified', changedFiles.updatedOutput());
+            core.setOutput('files_deleted', changedFiles.deletedOutput());
             process.exit(0);
         }
         catch (error) {

--- a/src/ChangedFiles.ts
+++ b/src/ChangedFiles.ts
@@ -1,0 +1,53 @@
+import {File} from './File'
+
+export class ChangedFiles {
+  updated: string[] = []
+  created: string[] = []
+  deleted: string[] = []
+  files: string[] = []
+
+  getOutput(files: string[], format: string): string {
+    if (format === 'json') {
+      return JSON.stringify(files)
+    } else {
+      return files.join(format)
+    }
+  }
+
+  createdOutput(format: string): string {
+    return this.getOutput(this.created, format)
+  }
+
+  fileOutput(format: string): string {
+    return this.getOutput(this.files, format)
+  }
+
+  updatedOutput(format: string): string {
+    return this.getOutput(this.updated, format)
+  }
+
+  deletedOutput(format: string): string {
+    return this.getOutput(this.deleted, format)
+  }
+}
+
+export async function sortChangedFiles(files: any): Promise<ChangedFiles> {
+  return files.reduce((acc: ChangedFiles, f: File) => {
+    if (f.status === 'added' || f.added) {
+      acc.created.push(f.filename === undefined ? f.added : f.filename)
+      acc.files.push(f.filename === undefined ? f.added : f.filename)
+    }
+    if (f.status === 'removed' || f.removed) {
+      acc.deleted.push(f.filename === undefined ? f.removed : f.filename)
+    }
+    if (f.status === 'modified' || f.modified) {
+      acc.updated.push(f.filename === undefined ? f.modified : f.filename)
+      acc.files.push(f.filename === undefined ? f.modified : f.filename)
+    }
+    if (f.status === 'renamed') {
+      acc.created.push(f.filename)
+      acc.deleted.push(f.previous_filename)
+    }
+    return acc
+  }, new ChangedFiles())
+}

--- a/src/File.ts
+++ b/src/File.ts
@@ -1,0 +1,9 @@
+export class File {
+  added: string = ''
+  modified: string = ''
+  removed: string = ''
+  filename: string = ''
+  status: string = ''
+  previous_filename: string = ''
+  distinct: boolean = true
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,30 @@ class ChangedFiles {
   created: string[] = []
   deleted: string[] = []
   files: string[] = []
+
+  getOutput(files: string[]): string {
+    if (core.getInput('plaintext')) {
+      return files.join(' ')
+    } else {
+      return JSON.stringify(files)
+    }
+  }
+
+  createdOutput(): string {
+    return this.getOutput(this.created)
+  }
+
+  fileOutput(): string {
+    return this.getOutput(this.files)
+  }
+
+  updatedOutput(): string {
+    return this.getOutput(this.updated)
+  }
+
+  deletedOutput(): string {
+    return this.getOutput(this.deleted)
+  }
 }
 
 class File {
@@ -109,31 +133,33 @@ async function run(): Promise<void> {
       )
       return
     }
+
     //write files to preserve original functionality
     fs.writeFileSync(
       `${process.env.HOME}/files.json`,
-      JSON.stringify(changedFiles.files),
+      changedFiles.fileOutput(),
       'utf-8'
     )
     fs.writeFileSync(
       `${process.env.HOME}/files_modified.json`,
-      JSON.stringify(changedFiles.updated),
+      changedFiles.updatedOutput(),
       'utf-8'
     )
     fs.writeFileSync(
       `${process.env.HOME}/files_added.json`,
-      JSON.stringify(changedFiles.created),
+      changedFiles.createdOutput(),
       'utf-8'
     )
     fs.writeFileSync(
       `${process.env.HOME}/files_deleted.json`,
-      JSON.stringify(changedFiles.deleted),
+      changedFiles.deletedOutput(),
       'utf-8'
     )
     //also export some outputs
-    core.setOutput('files_added', JSON.stringify(changedFiles.created))
-    core.setOutput('files_modified', JSON.stringify(changedFiles.updated))
-    core.setOutput('files_deleted', JSON.stringify(changedFiles.deleted))
+    core.setOutput('files', changedFiles.fileOutput())
+    core.setOutput('files_added', changedFiles.createdOutput())
+    core.setOutput('files_modified', changedFiles.updatedOutput())
+    core.setOutput('files_deleted', changedFiles.deletedOutput())
     process.exit(0)
   } catch (error) {
     core.error(error)


### PR DESCRIPTION
This creates the files and outputs in plain text instead of JSON strings. This is helpful for passing into other functions via command line (e.g. linters).

Note that I manually edited the .js files because I couldn't get `tsc` working.