### PR TITLE
Fix package.json main to use dist/index.js instead of lib/main.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "node": "12.16.3"
   },
   "description": "Creates outputs variables of files modified, added, or removed by a PR or Push.",
-  "main": "lib/main.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "yarn && tsc",
     "build-package": "yarn build --build tsconfig.build.json && ncc build",


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore



### Describe Changes

I tried requiring the npm package for this action, and require was looking for the pkg `main` which is an invalid path
