### PR TITLE
fix: Using platform-agnostic `homedir()` as output dir

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@trilom/file-changes-action",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/FilesHelper.ts
+++ b/src/FilesHelper.ts
@@ -1,5 +1,6 @@
 import {setOutput as coreSetOutput, debug as coreDebug} from '@actions/core'
 import {writeFileSync} from 'fs'
+import {homedir} from 'os'
 import {ChangedFiles} from 'typings/ChangedFiles'
 import {GitHubFile} from 'typings/GitHubFile'
 import {getErrorString} from './UtilsHelper'
@@ -89,16 +90,15 @@ export function writeFiles(format: string, key: string, files: string[]): void {
   try {
     const ext = getFormatExt(format)
     const fileName = key === 'files' ? `${key}${ext}` : `files_${key}${ext}`
+    const filePath = `${homedir()}/${fileName}`
     coreDebug(
-      `Writing output file ${
-        process.env.HOME
-      }/${fileName} with ${format} and files ${JSON.stringify(files, null, 2)}`
+      `Writing output file ${filePath} with ${format} and files ${JSON.stringify(
+        files,
+        null,
+        2
+      )}`
     )
-    writeFileSync(
-      `${process.env.HOME}/${fileName}`,
-      formatChangedFiles(format, files),
-      'utf-8'
-    )
+    writeFileSync(filePath, formatChangedFiles(format, files), 'utf-8')
   } catch (error) {
     const eString = `There was an issue writing output files.`
     throw new Error(


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
- Fixes #112

### Describe Changes
Switched out platform-specific `process.env.HOME` for platform agnostic `os.homedir()`.

Haven't adjusted unit tests, as they still feel appropriate. You could make the argument that we should mock the response from `os.homedir()` instead of allowing a real call to the underlay environment variables, but that would require some fairly significant refactoring of the tests.