### PR TITLE
add files_renamed documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ steps.file_changes.outputs.files_modified - `string` - The names of the updated 
 
 steps.file_changes.outputs.files_removed - `string` - The names of the removed files.  The output is dependant on the output input, default is a json string.
 
+### files_renamed
+
+steps.file_changes.outputs.files_renamed - `string` - The names of the renamed files.  The output is dependant on the output input, default is a json string.
+
 ## Example usage
 
 ```yaml
@@ -142,10 +146,12 @@ jobs:
           cat $HOME/files_modified.json
           cat $HOME/files_added.json
           cat $HOME/files_removed.json
+          cat $HOME/files_renamed.json
           echo '${{ steps.file_changes.outputs.files}}'
           echo '${{ steps.file_changes.outputs.files_modified}}'
           echo '${{ steps.file_changes.outputs.files_added}}'
           echo '${{ steps.file_changes.outputs.files_removed}}'
+          echo '${{ steps.file_changes.outputs.files_renamed}}'
 ```
 
 You can set the output and fileOutput to ',' for csv output.


### PR DESCRIPTION
### Type of Change

- [x] Documentation

### Resolves
- Fixes #108 

### Describe Changes

This will add clarity about the availability of files_renamed which I believe is causing the confusion people have voiced in #108 where it is not actually a bug, but just that it is not clear that this data is available. As far as I can tell (I don't actually know js/ts) the renamed files are getting added/processed here: https://github.com/trilom/file-changes-action/blob/a6ca26c14274c33b15e6499323aac178af06ad4b/src/FilesHelper.ts#L24-L30 and when I test trying to access the files_renamed object in my code that leverages this action it works as expected.
